### PR TITLE
feat(core-cache): configurable etcd prefix & etcd cluster path, allow removal of memcache instances

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,8 +29,10 @@ var etcdClient *etcd.Client
 
 var port int
 var prefix string
+var etcdClusterHost string
 
 func init() {
+	flag.StringVar(&etcdClusterHost, "C", "http://127.0.0.1:4001", "path to a known etcd cluster machine")
 	flag.IntVar(&port, "p", 22122, "the port of the ds-memcached proxy")
 	flag.StringVar(&prefix, "prefix", "/service/memcached", "the etcd prefix")
 }
@@ -41,9 +43,12 @@ func main() {
 
 	c = consistent.New()
 
-	etcdClient = etcd.NewClient()
+	etcdClient = etcd.NewClient([]string{etcdClusterHost})
 
-	etcdClient.SyncCluster()
+	if ok := etcdClient.SyncCluster(); !ok {
+		fmt.Println("Failed to sync with cluster. \nPlease make sure the cluster can be reached via the provided URL.")
+		os.Exit(1)
+	}
 
 	presps, err := etcdClient.Get(prefix)
 

--- a/main.go
+++ b/main.go
@@ -28,9 +28,11 @@ var c *consistent.Consistent
 var etcdClient *etcd.Client
 
 var port int
+var prefix string
 
 func init() {
 	flag.IntVar(&port, "p", 22122, "the port of the ds-memcached proxy")
+	flag.StringVar(&prefix, "prefix", "/service/memcached", "the etcd prefix")
 }
 
 func main() {
@@ -43,7 +45,7 @@ func main() {
 
 	etcdClient.SyncCluster()
 
-	presps, err := etcdClient.Get("/service/memcached")
+	presps, err := etcdClient.Get(prefix)
 
 	if err != nil {
 		fmt.Println("Add at least one memcached instance under path")
@@ -64,7 +66,7 @@ func watch() {
 	receiver := make(chan *store.Response, 10)
 	stop := make(chan bool, 1)
 	go update(receiver)
-	etcdClient.Watch("/service/memcached", 0, receiver, stop)
+	etcdClient.Watch(prefix, 0, receiver, stop)
 }
 
 func update(receiver chan *store.Response) {


### PR DESCRIPTION
This PR adds 3 features:
- make it possible to remove and replace memcached servers on the fly
- make the etcd prefix configurable
- make the path to the etcd cluster configurable (stick to the 127.0.0.0.1:4001 default if it's not specified)
